### PR TITLE
Fix length padding in NvmFile Flush and Read

### DIFF
--- a/nvm/env_nvm_file.cc
+++ b/nvm/env_nvm_file.cc
@@ -328,7 +328,7 @@ Status NvmFile::Flush(bool padded) {
     return Status::OK();
   }
 
-  if (padded) {
+  if (padded && (buf_nbytes_ % stripe_nbytes_ != 0)) {
     //size_t pad_nbytes = align_nbytes_ - (buf_nbytes_ % align_nbytes_);
     pad_nbytes = stripe_nbytes_ - (buf_nbytes_ % stripe_nbytes_);
 
@@ -519,7 +519,7 @@ Status NvmFile::Read(
   // Now we know that: '0 < n <= nbytes_from_offset'
 
   uint64_t aligned_offset = offset - offset % align_nbytes_;
-  uint64_t aligned_n = (((n + align_nbytes_ -1) / align_nbytes_) + 1) * align_nbytes_;
+  uint64_t aligned_n = (((n + align_nbytes_ - 1) / align_nbytes_)) * align_nbytes_;
   uint64_t skip_head_nbytes = offset - aligned_offset;
   uint64_t skip_tail_nbytes = aligned_n - n;
 


### PR DESCRIPTION
NvmFile Flush and Read calculate padding bytes falsely.