### PR TITLE
V5.4.6 ocssd debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ CLEAN_FILES = # deliberately empty, so we can append below.
 CFLAGS += ${EXTRA_CFLAGS}
 CXXFLAGS += ${EXTRA_CXXFLAGS}
 LDFLAGS += $(EXTRA_LDFLAGS)
+LDFLAGS += -fopenmp -llightnvm $(EXTRA_LDFLAGS)
 MACHINE ?= $(shell uname -m)
 ARFLAGS = rs
 

--- a/nvm/env_nvm_file.cc
+++ b/nvm/env_nvm_file.cc
@@ -519,8 +519,8 @@ Status NvmFile::Read(
   // Now we know that: '0 < n <= nbytes_from_offset'
 
   uint64_t aligned_offset = offset - offset % align_nbytes_;
-  uint64_t aligned_n = (((n + align_nbytes_ - 1) / align_nbytes_)) * align_nbytes_;
-  uint64_t skip_head_nbytes = offset - aligned_offset;
+  uint64_t aligned_n = ((((n + align_nbytes_ - 1) / align_nbytes_)) + 1) * align_nbytes_;
+	uint64_t skip_head_nbytes = offset - aligned_offset;
   uint64_t skip_tail_nbytes = aligned_n - n;
 
   NVM_DBG(this, "aligned_n(" << aligned_n << ")");

--- a/nvm/env_nvm_file.cc
+++ b/nvm/env_nvm_file.cc
@@ -520,7 +520,7 @@ Status NvmFile::Read(
 
   uint64_t aligned_offset = offset - offset % align_nbytes_;
   uint64_t aligned_n = ((((n + align_nbytes_ - 1) / align_nbytes_)) + 1) * align_nbytes_;
-	uint64_t skip_head_nbytes = offset - aligned_offset;
+  uint64_t skip_head_nbytes = offset - aligned_offset;
   uint64_t skip_tail_nbytes = aligned_n - n;
 
   NVM_DBG(this, "aligned_n(" << aligned_n << ")");


### PR DESCRIPTION
:octocat: debug for crc mismatch error :octocat:</p>
---
### Overview
`[Simple Description]`

The cause of the crc mismatch problem is that the size of ***aligned_n*** for reading is smaller than the size required.

To get into details, running db_bench, the mismatch error occuurred when reading in the index block of **59,                  596bytes(including 5bytes for CRC)**. ( Maybe even read the other blocks will have similar problems. )

The actual offset of index block is ***202488477***.
Currently, the code reads ***aligned_n(65536)*** from <em>**aligned\_offset(2024865792)**</em>. So, it cannot cover whole     index block and cause CRC mismatch problem.

That is, **aligned_offset(2024865792) + aligned_n(65536)** become less than **offset(202488477) + index block size(59596)**
Here is part of related log.
(https://github.com/RockyLim92/RocksDB_OCSSD_debug/blob/master/asset/log.png)

The variable ***aligned_n*** sould be set to cover the whole block including CRC 32 bits and I fixed around here.