### PR TITLE
Simplification and read alignment fix

### DIFF
--- a/nvm/env_nvm.h
+++ b/nvm/env_nvm.h
@@ -165,9 +165,19 @@ public:
   std::string GetDevName(void) const { return dev_name_; }
   std::string GetDevPath(void) const { return dev_path_; }
   std::string GetMapping(void) const { return mapping_; }
-  size_t GetHeight(void) const { return height_; }
 
+  size_t GetHeight(void) const { return height_; }
   size_t GetPunitCount(void) const { return punits_.size(); }
+  size_t GetReadAlignment(void) const { return geo_->l.nbytes; }
+  size_t GetWriteAlignment(void) const { return nvm_dev_get_ws_opt(dev_) * geo_->l.nbytes; }
+  size_t GetChunkSize(void) const { return GetReadAlignment() * geo_->l.nsectr; }
+  size_t GetNumberOfChunksInBlock(void) const {
+    return (
+      strcmp(mapping_.c_str(), "2") == 0
+      ? (GetHeight() * geo_->l.npunit)
+      : GetPunitCount()
+    );
+  }
 
 protected:
 
@@ -259,7 +269,6 @@ private:
   std::string mpath_;
 
   size_t align_nbytes_;
-  size_t stripe_nbytes_;
   size_t blk_nbytes_;
 
   char *buf_;

--- a/nvm/env_nvm_file.cc
+++ b/nvm/env_nvm_file.cc
@@ -39,7 +39,6 @@ NvmFile::NvmFile(
   NVM_DBG(this, "mpath_:" << mpath_);
 
   struct nvm_dev *dev = env_->store_->GetDev();
-  const struct nvm_geo *geo = nvm_dev_get_geo(dev);
 
   if (env_->posix_->FileExists(mpath_).ok()) {          // Read meta from file
     std::string content;


### PR DESCRIPTION
This PR simplifies and moves the devices specific calculations to the NvmStore class. It also makes it more clear what the variables should hold. `blk_nbytes_` was for example refactored from `stripe_nbytes_ * (geo->l.nsectr / nvm_dev_get_ws_opt(dev)) * env_->store_->GetPunitCount();` to `env_->store_->GetChunkSize() * env_->store_->GetNumberOfChunksInBlock();`.

Furthermore this PR differentiates on reading alignment and write alignment. With the current implementation, RocksDB can be forced to read way more than neccessary from the device, as the alignment must match the minimum write size. Now RocksDB must only align reads to the size of a sector.

This PR integrated the fix from #2, as it is required for the other changes to work correctly.
